### PR TITLE
More than one Field per Line

### DIFF
--- a/Influx/Private/Out-InfluxEscapeString.ps1
+++ b/Influx/Private/Out-InfluxEscapeString.ps1
@@ -24,6 +24,7 @@
         $String
     )
     process {
-        $String -Replace '(\s|\=|,)', '\$1'
+        $String -Replace '(\s|=|,|\\|")', '\$1'
+
     }
 }

--- a/Influx/Public/ConvertTo-InfluxLineString.ps1
+++ b/Influx/Public/ConvertTo-InfluxLineString.ps1
@@ -93,7 +93,7 @@
             
             #No existance check performed since the parameter is mandatory
             $MetricData = foreach ($Metric in $MetricObject.Metrics.Keys) {
-                if ([string]::IsNullOrEmpty($MetricObject.Metrics[$Metric])) {
+                if ($ExcludeEmptyMetric -and [string]::IsNullOrEmpty($MetricObject.Metrics[$Metric])) {
                     Write-Verbose "$Metric skipped as -ExcludeEmptyMetric was specified and the value is null or empty."
                 }
                 #if not a number wrap in "" and escape all influx special char

--- a/Influx/Public/ConvertTo-InfluxLineString.ps1
+++ b/Influx/Public/ConvertTo-InfluxLineString.ps1
@@ -58,7 +58,8 @@
         [switch]
         $ExcludeEmptyMetric
     )
-    Begin { }
+    Begin {
+    }
     Process {
         if (-not $InputObject) {
             $InputObject = @{
@@ -88,26 +89,27 @@
                     }
                 }
                 $TagData = $TagData -Join ','
-                $TagData = ",$TagData"
             }
-        
-            $Body = foreach ($Metric in $MetricObject.Metrics.Keys) {
             
-                if ($ExcludeEmptyMetric -and [string]::IsNullOrEmpty($MetricObject.Metrics[$Metric])) {
+            #No existance check performed since the parameter is mandatory
+            $MetricData = foreach ($Metric in $MetricObject.Metrics.Keys) {
+                if ([string]::IsNullOrEmpty($MetricObject.Metrics[$Metric])) {
                     Write-Verbose "$Metric skipped as -ExcludeEmptyMetric was specified and the value is null or empty."
                 }
-                Else {
-                    if ($MetricObject.Metrics[$Metric] -isnot [ValueType]) { 
-                        $MetricValue = '"' + $MetricObject.Metrics[$Metric] + '"'
-                    }
-                    else {
-                        $MetricValue = $MetricObject.Metrics[$Metric] | Out-InfluxEscapeString
-                    }
-            
-                    "$($MetricObject.Measure | Out-InfluxEscapeString)$TagData $($Metric | Out-InfluxEscapeString)=$MetricValue $timeStampNanoSecs"
-                }            
+                #if not a number wrap in "" and escape all influx special char
+                elseif ($MetricObject.Metrics[$Metric] -isnot [ValueType]) {
+                    $MetricValue = '"' + ($MetricObject.Metrics[$Metric] | Out-InfluxEscapeString) + '"'
+                }
+                else {
+                    $MetricValue = $MetricObject.Metrics[$Metric]
+                }
+
+                "$($Metric | Out-InfluxEscapeString)=$($MetricValue)"
             }
-        
+            $MetricData = $MetricData -Join ','
+
+            $Body = "$($MetricObject.Measure | Out-InfluxEscapeString)"+ $(if($TagData) {","}) + $TagData + " " + $MetricData + $(if($timeStampNanoSecs) {" "}) + $timeStampNanoSecs 
+
             if ($Body) {
                 $Body = $Body -Join "`n"
 

--- a/Influx/Public/ConvertTo-InfluxLineString.ps1
+++ b/Influx/Public/ConvertTo-InfluxLineString.ps1
@@ -88,7 +88,8 @@
                         "$($Tag | Out-InfluxEscapeString)=$($MetricObject.Tags[$Tag] | Out-InfluxEscapeString)"
                     }
                 }
-                $TagData = $TagData -Join ','
+                #$TagData = $TagData -Join ','
+                $TagData = ($TagData | Sort-Object) -Join ',' 
             }
             
             #No existance check performed since the parameter is mandatory

--- a/Influx/Public/ConvertTo-InfluxLineString.ps1
+++ b/Influx/Public/ConvertTo-InfluxLineString.ps1
@@ -88,7 +88,6 @@
                         "$($Tag | Out-InfluxEscapeString)=$($MetricObject.Tags[$Tag] | Out-InfluxEscapeString)"
                     }
                 }
-                #$TagData = $TagData -Join ','
                 $TagData = ($TagData | Sort-Object) -Join ',' 
             }
             
@@ -101,6 +100,7 @@
                 elseif ($MetricObject.Metrics[$Metric] -isnot [ValueType]) {
                     $MetricValue = '"' + ($MetricObject.Metrics[$Metric] | Out-InfluxEscapeString) + '"'
                 }
+                #no need to escape numeric values
                 else {
                     $MetricValue = $MetricObject.Metrics[$Metric]
                 }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Get-TFSBuildMetric -TFSRootURL 'https://mytfsurl.local/tfs' -TFSCollection somec
 
 There are also `Send-SomeMetric` cmdlets that were implemented to retrieve metrics from a datasource and send it to Influx via the REST API in one step. These continue to exist for backwards compatibility, but for more flexibility use the `Get-SomeMetric` cmdlets and pipe their results to whatever `Write-*` method you want to use for interacting with Influx.
 
+Results of other Powershell commands or custom objects can be sent to Influx. Simply map the object properties to a Metric object using the ConvertTo-Metric cmdlet.
+```
+#Send data from Get-Process to InfluxDB using the REST API with authentication
+Get-Process -Name <__Processname__> | ConvertTo-Metric -Measure test -MetricProperty CPU,PagedmemorySize -TagProperty Handles,Id,ProcessName | Write-Influx -Database windows_system_monitor -Server http://<__InfluxEndpoint__>:8086 -Credential (Get-Credential) -Verbose
+```
+
 ## Implementation Example
 
 Here is an example script which could be run as a scheduled task every 5 minutes to send stats from various sources in to Influx. Note this requires a number of dependent modules be present such as the VMWare PowerShell cmdlets.

--- a/Tests/ConvertTo-InfluxLineString.Tests.ps1
+++ b/Tests/ConvertTo-InfluxLineString.Tests.ps1
@@ -159,7 +159,7 @@ Describe "ConvertTo-InfluxLineString Tag Sorting PS$PSVersion" {
         $WriteInflux = ConvertTo-InfluxLineString -Measure Test -Tags @{Server = 'Host01';Database='MyDb';Alert='False'} -Metrics @{CPU = 20; Status = 'PoweredOn'}
         Write-Host $WriteInflux
         Context 'The Tags should be sorted alphabetically' {
-            It 'The output should be BeExactly Test,Alert=False,Database=MyDb,Server=Host01 CPU=20,Status="PoweredOn"' {
+            It 'The output should be be exactly: Test,Alert=False,Database=MyDb,Server=Host01 CPU=20,Status="PoweredOn"' {
                 $WriteInflux | Should -BeExactly 'Test,Alert=False,Database=MyDb,Server=Host01 CPU=20,Status="PoweredOn"'
             }
         }

--- a/Tests/ConvertTo-InfluxLineString.Tests.ps1
+++ b/Tests/ConvertTo-InfluxLineString.Tests.ps1
@@ -17,7 +17,7 @@ Describe "ConvertTo-InfluxLineString PS$PSVersion" {
         Mock ConvertTo-UnixTimeNanosecond { '1483274062120000000' }
        
         Context 'Simulating successful output' {
-           
+
             $WriteInflux = ConvertTo-InfluxLineString -Measure WebServer -Tags @{Server = 'Host01'} -Metrics @{CPU = 100; Status = 'PoweredOn'} -Timestamp (Get-Date)
 
             It 'ConvertTo-InfluxLineString should return a string' {
@@ -147,6 +147,20 @@ Describe "ConvertTo-InfluxLineString PS$PSVersion" {
             }
             It 'Should call Out-InfluxEscapeString exactly 10 times' {
                 Assert-MockCalled Out-InfluxEscapeString -Exactly 10
+            }
+        }
+    }
+}
+
+Describe "ConvertTo-InfluxLineString Tag Sorting PS$PSVersion" {
+    
+    InModuleScope Influx {
+        
+        $WriteInflux = ConvertTo-InfluxLineString -Measure Test -Tags @{Server = 'Host01';Database='MyDb';Alert='False'} -Metrics @{CPU = 20; Status = 'PoweredOn'}
+        Write-Host $WriteInflux
+        Context 'The Tags should be sorted alphabetically' {
+            It 'The output should be BeExactly Test,Alert=False,Database=MyDb,Server=Host01 CPU=20,Status="PoweredOn"' {
+                $WriteInflux | Should -BeExactly 'Test,Alert=False,Database=MyDb,Server=Host01 CPU=20,Status="PoweredOn"'
             }
         }
     }

--- a/Tests/ConvertTo-InfluxLineString.Tests.ps1
+++ b/Tests/ConvertTo-InfluxLineString.Tests.ps1
@@ -29,8 +29,8 @@ Describe "ConvertTo-InfluxLineString PS$PSVersion" {
             It 'Should call ConvertTo-UnixTimeNanosecond exactly 1 time' {
                 Assert-MockCalled ConvertTo-UnixTimeNanosecond -Exactly 1
             }
-            It 'Should call Out-InfluxEscapeString exactly 7 times' {
-                Assert-MockCalled Out-InfluxEscapeString -Exactly 7
+            It 'Should call Out-InfluxEscapeString exactly 6 times' {
+                Assert-MockCalled Out-InfluxEscapeString -Exactly 6
             }
         }
 
@@ -55,8 +55,8 @@ Describe "ConvertTo-InfluxLineString PS$PSVersion" {
             It 'Should call ConvertTo-UnixTimeNanosecond exactly 1 time' {
                 Assert-MockCalled ConvertTo-UnixTimeNanosecond -Exactly 1
             }
-            It 'Should call Out-InfluxEscapeString exactly 9 times' {
-                Assert-MockCalled Out-InfluxEscapeString -Exactly 9
+            It 'Should call Out-InfluxEscapeString exactly 8 times' {
+                Assert-MockCalled Out-InfluxEscapeString -Exactly 8
             }
         }
 
@@ -70,8 +70,8 @@ Describe "ConvertTo-InfluxLineString PS$PSVersion" {
             It 'Should execute all verifiable mocks' {
                 Assert-VerifiableMock
             }
-            It 'Should call Out-InfluxEscapeString exactly 7 times' {
-                Assert-MockCalled Out-InfluxEscapeString -Exactly 7
+            It 'Should call Out-InfluxEscapeString exactly 6 times' {
+                Assert-MockCalled Out-InfluxEscapeString -Exactly 6
             }
             It 'Should call ConvertTo-UnixTimeNanosecond exactly 0 times' {
                 Assert-MockCalled ConvertTo-UnixTimeNanosecond -Exactly 0
@@ -91,8 +91,8 @@ Describe "ConvertTo-InfluxLineString PS$PSVersion" {
             It 'Should call ConvertTo-UnixTimeNanosecond exactly 1 time' {
                 Assert-MockCalled ConvertTo-UnixTimeNanosecond -Exactly 1
             }
-            It 'Should call Out-InfluxEscapeString exactly 8 times' {
-                Assert-MockCalled Out-InfluxEscapeString -Exactly 8
+            It 'Should call Out-InfluxEscapeString exactly 5 times' {
+                Assert-MockCalled Out-InfluxEscapeString -Exactly 5
             }
         }
 
@@ -109,8 +109,8 @@ Describe "ConvertTo-InfluxLineString PS$PSVersion" {
             It 'Should call ConvertTo-UnixTimeNanosecond exactly 1 time' {
                 Assert-MockCalled ConvertTo-UnixTimeNanosecond -Exactly 1
             }
-            It 'Should call Out-InfluxEscapeString exactly 7 times' {
-                Assert-MockCalled Out-InfluxEscapeString -Exactly 7
+            It 'Should call Out-InfluxEscapeString exactly 5 times' {
+                Assert-MockCalled Out-InfluxEscapeString -Exactly 5
             }
         }
 

--- a/Tests/ConvertTo-InfluxLineString.Tests.ps1
+++ b/Tests/ConvertTo-InfluxLineString.Tests.ps1
@@ -109,8 +109,8 @@ Describe "ConvertTo-InfluxLineString PS$PSVersion" {
             It 'Should call ConvertTo-UnixTimeNanosecond exactly 1 time' {
                 Assert-MockCalled ConvertTo-UnixTimeNanosecond -Exactly 1
             }
-            It 'Should call Out-InfluxEscapeString exactly 5 times' {
-                Assert-MockCalled Out-InfluxEscapeString -Exactly 5
+            It 'Should call Out-InfluxEscapeString exactly 6 times' {
+                Assert-MockCalled Out-InfluxEscapeString -Exactly 6
             }
         }
 


### PR DESCRIPTION
Here is what has been edited:

- Having multiple fields don't duplicate lines. i.e. this input command:
ConvertTo-InfluxLineString -Measure Test -Tags @{Server = 'Host01';Database='MyDb';Alert='False'} -Metrics @{CPU = 20; Status = 'PoweredOn'}
Produces this output:
Test,Alert=False,Database=MyDb,Server=Host01 CPU=20,Status="PoweredOn"
Instead of:
Test,Alert=False,Database=MyDb,Server=Host01 CPU=20
Test,Alert=False,Database=MyDb,Server=Host01 Status="PoweredOn"

- The tags are sorted alphabetically in the output string (this should improve performance)
- Added an additional usage sample to the README, to send results of other PowerShell commands 
- The tests have been updated to reflect the changes and a test to check the correct sorting has been added

I also tested the correct write over API but more tests might be required