### PR TITLE
Null empty fix - fixed a wrong parameter in function call

### DIFF
--- a/Influx/Public/ConvertTo-InfluxLineString.ps1
+++ b/Influx/Public/ConvertTo-InfluxLineString.ps1
@@ -98,9 +98,9 @@
                 }
                 #if not a number wrap in "" and escape all influx special char
                 elseif ($MetricObject.Metrics[$Metric] -isnot [ValueType]) {
-                    $MetricValue = '"' + ($MetricObject.Metrics[$Metric] | Out-InfluxEscapeString) + '"'
+                    $MetricValue = '"' + ($MetricObject.Metrics[$Metric] | Out-InfluxEscapeString -StringType FieldTextValue ) + '"'
                     #Write output
-                    "$($Metric | Out-InfluxEscapeString -StringType FieldTextValue)=$($MetricValue)"
+                    "$($Metric | Out-InfluxEscapeString)=$($MetricValue)"
                 }
                 #no need to escape numeric values
                 else {


### PR DESCRIPTION
In a point the function "Out-InfluxEscapeString" was called with the wrong parameter, causing to escape more chars than necessary. (nothing dangerous or critical, just some useless additional char in the output)