### PR TITLE
I would like to propose some improvements on the Influx LP usage and SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+LocalTests/Write-Influx.Test.Local.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-LocalTests/Write-Influx.Test.Local.ps1

--- a/Documentation/Write-Influx.md
+++ b/Documentation/Write-Influx.md
@@ -7,28 +7,28 @@ Writes data to Influx via the REST API.
 
 ### Measure_v1 (Default)
 ```
-Write-Influx -Measure <String> [-Tags <Hashtable>] -Metrics <Hashtable> [-TimeStamp <DateTime>]
+Write-Influx -Measure <String> [-Tags <Hashtable>] -Metrics <Hashtable> [-TimeStamp <DateTime>] [-SingleLineMetrics]
  [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric] -Database <String>
- [-Credential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Credential <PSCredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### MetricObject_v2
 ```
-Write-Influx -InputObject <PSObject[]> [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric]
- -Organisation <String> -Bucket <String> -Token <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Write-Influx -InputObject <PSObject[]> [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric] [-SingleLineMetrics]
+ -Organisation <String> -Bucket <String> -Token <String> [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### MetricObject_v1
 ```
-Write-Influx -InputObject <PSObject[]> [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric]
- -Database <String> [-Credential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Write-Influx -InputObject <PSObject[]> [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric] [-SingleLineMetrics]
+ -Database <String> [-Credential <PSCredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Measure_v2
 ```
-Write-Influx -Measure <String> [-Tags <Hashtable>] -Metrics <Hashtable> [-TimeStamp <DateTime>]
+Write-Influx -Measure <String> [-Tags <Hashtable>] -Metrics <Hashtable> [-TimeStamp <DateTime>] [-SingleLineMetrics]
  [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric] -Organisation <String> -Bucket <String>
- -Token <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ -Token <String> [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -188,6 +188,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -SingleLineMetrics
+Switch: Sends all measured values for every single object passed within the single Influx Line Protocol line.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Database
 The name of the Influx database to write to.
 (This is an InfluxDB v1.x Parameter)
@@ -267,6 +282,22 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -TrustServerCertificate
+Switch: Skips Server SSL certificate validation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.

--- a/Documentation/Write-Influx.md
+++ b/Documentation/Write-Influx.md
@@ -190,7 +190,7 @@ Accept wildcard characters: False
 ```
 
 ### -SingleLineMetrics
-Switch: Sends all measured values for every single object passed within the single Influx Line Protocol line.
+Switch: Sends all measured values for every Metric object or Measure passed within the single Influx Line Protocol line.
 
 ```yaml
 Type: SwitchParameter

--- a/Documentation/Write-Influx.md
+++ b/Documentation/Write-Influx.md
@@ -12,23 +12,24 @@ Write-Influx -Measure <String> [-Tags <Hashtable>] -Metrics <Hashtable> [-TimeSt
  [-Credential <PSCredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### MetricObject_v2
-```
-Write-Influx -InputObject <PSObject[]> [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric] [-SingleLineMetrics]
- -Organisation <String> -Bucket <String> -Token <String> [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### MetricObject_v1
-```
-Write-Influx -InputObject <PSObject[]> [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric] [-SingleLineMetrics]
- -Database <String> [-Credential <PSCredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
 ### Measure_v2
 ```
 Write-Influx -Measure <String> [-Tags <Hashtable>] -Metrics <Hashtable> [-TimeStamp <DateTime>] [-SingleLineMetrics]
  [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric] -Organisation <String> -Bucket <String>
  -Token <String> [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+### MetricObject_v2
+```
+Write-Influx -InputObject <PSObject[]> [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric]
+ [-SingleLineMetrics]  -Organisation <String> -Bucket <String> -Token <String> [-TrustServerCertificate]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### MetricObject_v1
+```
+Write-Influx -InputObject <PSObject[]> [-Server <String>] [-Bulk] [-BulkSize <Int32>] [-ExcludeEmptyMetric]
+ [-SingleLineMetrics]  -Database <String> [-Credential <PSCredential>] [-TrustServerCertificate]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/Influx/Public/Write-Influx.ps1
+++ b/Influx/Public/Write-Influx.ps1
@@ -53,7 +53,7 @@
             Switch: Skips Server SSL certificate validation.
 
         .PARAMETER SingleLineMetrics
-            Switch: Sends all measured values for every single object passed within the single Influx Line Protocol line.
+            Switch: Sends all measured values for every Metric object or Measure passed within the single Influx Line Protocol line.
 
         .EXAMPLE
             Write-Influx -Measure WebServer -Tags @{Server='Host01'} -Metrics @{CPU=100; Memory=50} -Database Web -Server http://myinflux.local:8086

--- a/Influx/Public/Write-Influx.ps1
+++ b/Influx/Public/Write-Influx.ps1
@@ -49,6 +49,12 @@
             Switch: Use to exclude null or empty metric values from being sent. Useful where a metric is initially created as an integer but then
             an empty or null instance of that metric would attempt to be sent as an empty string, resulting in a datatype conflict.
 
+        .PARAMETER TrustServerCertificate
+            Switch: Skips Server SSL certificate validation.
+
+        .PARAMETER SingleLineMetrics
+            Switch: Sends all measured values for every single object passed within the single Influx Line Protocol line.
+
         .EXAMPLE
             Write-Influx -Measure WebServer -Tags @{Server='Host01'} -Metrics @{CPU=100; Memory=50} -Database Web -Server http://myinflux.local:8086
             
@@ -120,7 +126,13 @@
         [Parameter(ParameterSetName = 'Measure_v2', Mandatory)]
         [Parameter(ParameterSetName = 'MetricObject_v2', Mandatory)]
         [string]
-        $Token
+        $Token,
+
+        [switch]
+        $TrustServerCertificate,
+
+        [switch]
+        $SingleLineMetrics
     )
 
     begin {
@@ -133,6 +145,10 @@
             $Headers = @{
                 Authorization = "Basic $EncodedCreds"
             }
+        }
+
+        if ($TrustServerCertificate) {
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
         }
 
         if ($Database) {
@@ -180,23 +196,45 @@
                 $TagData = $TagData -Join ','
                 $TagData = ",$TagData"
             }
-        
-            $Body = foreach ($Metric in $MetricObject.Metrics.Keys) {
-            
-                if ($ExcludeEmptyMetric -and [string]::IsNullOrEmpty($MetricObject.Metrics[$Metric])) {
-                    Write-Verbose "$Metric skipped as -ExcludeEmptyMetric was specified and the value is null or empty."
-                }
-                else {
-                    if ($MetricObject.Metrics[$Metric] -isnot [ValueType]) { 
-                        $MetricValue = '"' + $MetricObject.Metrics[$Metric] + '"'
+ 
+            if($SingleLineMetrics) {
+                $MetricData = foreach ($Metric in $MetricObject.Metrics.Keys) {
+                    if ($ExcludeEmptyMetric -and [string]::IsNullOrEmpty($MetricObject.Metrics[$Metric])) {
+                        Write-Verbose "$Metric skipped as -ExcludeEmptyMetric was specified and the value is null or empty."
                     }
                     else {
-                        $MetricValue = $MetricObject.Metrics[$Metric] | Out-InfluxEscapeString
+                        if ($MetricObject.Metrics[$Metric] -isnot [ValueType]) { 
+                            "$($Metric | Out-InfluxEscapeString)=""$($MetricObject.Metrics[$Metric])"""
+                        }
+                        else {
+                            "$($Metric | Out-InfluxEscapeString)=$($MetricObject.Metrics[$Metric] | Out-InfluxEscapeString)"
+                        }
                     }
-            
-                    "$($MetricObject.Measure | Out-InfluxEscapeString)$TagData $($Metric | Out-InfluxEscapeString)=$MetricValue $timeStampNanoSecs"
-                }            
+                }
+                $MetricData = $MetricData -Join ','
+
+                $Body = "$($MetricObject.Measure | Out-InfluxEscapeString)$TagData $MetricData $timeStampNanoSecs"
             }
+            else {
+
+                $Body = foreach ($Metric in $MetricObject.Metrics.Keys) {
+            
+                    if ($ExcludeEmptyMetric -and [string]::IsNullOrEmpty($MetricObject.Metrics[$Metric])) {
+                        Write-Verbose "$Metric skipped as -ExcludeEmptyMetric was specified and the value is null or empty."
+                    }
+                    else {
+                        if ($MetricObject.Metrics[$Metric] -isnot [ValueType]) { 
+                            $MetricValue = '"' + $MetricObject.Metrics[$Metric] + '"'
+                        }
+                        else {
+                            $MetricValue = $MetricObject.Metrics[$Metric] | Out-InfluxEscapeString
+                        }
+                
+                        "$($MetricObject.Measure | Out-InfluxEscapeString)$TagData $($Metric | Out-InfluxEscapeString)=$MetricValue $timeStampNanoSecs"
+                    }            
+                }
+            }
+
         
             if ($Body) {
                 $Body = $Body -Join "`n"


### PR DESCRIPTION
Hi Everyone,
I would like to propose some improvements to the Influx LP usage and SSL.
The first one is to implement SSL certificate validation skip support.
The second one is to add support to send all measured values for the same tag set + timestamp in the same line. This will decrease the body size.
The message bulked body w/o this switch looks like:
```
testmeasure1,ENV=test,Hostname=FRSCBVAXMTR001P Memory=50 1696529658268541440
testmeasure1,ENV=test,Hostname=FRSCBVAXMTR001P CPU=10 1696529658268541440
```

With this switch, support added and enabled it will look like this
`testmeasure1,ENV=test,Hostname=FRSCBVAXMTR001P Memory=50,CPU=10 1696529658268541440`
